### PR TITLE
Add Attribute to Configure Background Corner Radius

### DIFF
--- a/lib/src/main/java/com/davidmiguel/multistateswitch/MultiStateSwitch.kt
+++ b/lib/src/main/java/com/davidmiguel/multistateswitch/MultiStateSwitch.kt
@@ -31,6 +31,7 @@ import kotlin.math.abs
 
 // Num of states used in editor preview
 private const val DEFAULT_NUM_STATES = 3
+private const val DEFAULT_RADIUS = 100f
 
 // Overflow of the shadow
 private const val SHADOW_TOP_OVERFLOW_DP = 2f
@@ -47,6 +48,7 @@ class MultiStateSwitch @JvmOverloads constructor(
     // START Styleable properties
     @ColorInt
     private var switchBackgroundColor: Int = 0
+    private var switchBackgroundRadius: Float = 0f
 
     @ColorInt
     private var textColor: Int = 0
@@ -115,6 +117,7 @@ class MultiStateSwitch @JvmOverloads constructor(
         val a = context.obtainStyledAttributes(attrs, R.styleable.MultiStateSwitch, defStyleAttr, defStyleRes)
         try {
             switchBackgroundColor = a.getColor(R.styleable.MultiStateSwitch_multistateswitch_background_color, 0)
+            switchBackgroundRadius = a.getFloat(R.styleable.MultiStateSwitch_multistateswitch_background_radius, DEFAULT_RADIUS)
             textColor = a.getColor(R.styleable.MultiStateSwitch_multistateswitch_text_color, 0)
             textSize = a.getDimensionPixelSize(R.styleable.MultiStateSwitch_multistateswitch_text_size, 0)
             currentStateIndex = a.getInt(R.styleable.MultiStateSwitch_multistateswitch_selected_state_index, 0)
@@ -138,6 +141,7 @@ class MultiStateSwitch @JvmOverloads constructor(
         shadowBottomOverflowPx = SHADOW_BOTTOM_OVERFLOW_DP.dp2px.toInt()
         // Background
         background = ContextCompat.getDrawable(context, R.drawable.multistateswitch_background)!!.mutate() as GradientDrawable
+        background.cornerRadius = switchBackgroundRadius.dp2px
         background.setColor(switchBackgroundColor)
     }
 

--- a/lib/src/main/res/values/attrs.xml
+++ b/lib/src/main/res/values/attrs.xml
@@ -5,6 +5,7 @@
     <declare-styleable name="MultiStateSwitch">
 
         <attr name="multistateswitch_background_color" format="color|reference" />
+        <attr name="multistateswitch_background_radius" format="float|reference" />
         <attr name="multistateswitch_text_color" format="color|reference" />
         <attr name="multistateswitch_text_size" format="dimension|reference" />
         <attr name="multistateswitch_selected_state_index" format="integer|reference" />

--- a/sample/src/main/java/com/davidmiguel/multistateswitch/sample/MainActivity.kt
+++ b/sample/src/main/java/com/davidmiguel/multistateswitch/sample/MainActivity.kt
@@ -24,6 +24,7 @@ class MainActivity : AppCompatActivity(), StateListener {
         setupDefaultSwitch()
         setupDisabledSwitch()
         setupCustomizedSwitch()
+        setupCustomizedRadiusSwitch()
         setupAddRemoveSwitch()
         setupViewPagerBtn()
     }
@@ -69,6 +70,11 @@ class MainActivity : AppCompatActivity(), StateListener {
         )
         binding.customizedSwitch.addStateListener(this)
         setupCustomizedButtons()
+    }
+
+    private fun setupCustomizedRadiusSwitch() {
+        binding.radiusSwitch.addStatesFromStrings(listOf("Off", "x2", "x3", "x4", "x5"))
+        binding.radiusSwitch.addStateListener(this)
     }
 
     private fun setupCustomizedButtons() {

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -79,6 +79,26 @@
                 app:multistateswitch_selected_state_index="1" />
 
             <TextView
+                android:id="@+id/radiusLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/customized_radius_label"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/customizedSwitch" />
+
+            <com.davidmiguel.multistateswitch.MultiStateSwitch
+                android:id="@+id/radiusSwitch"
+                android:layout_width="wrap_content"
+                android:layout_height="55dp"
+                android:layout_marginTop="8dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/radiusLabel"
+                app:multistateswitch_background_radius="8" />
+
+            <TextView
                 android:id="@+id/selectLabel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -86,7 +106,7 @@
                 android:text="@string/select_label"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/customizedSwitch" />
+                app:layout_constraintTop_toBottomOf="@id/radiusSwitch" />
 
             <Button
                 android:id="@+id/select1Btn"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="default_label">Default settings:</string>
     <string name="disabled_label">With disabled state:</string>
     <string name="customized_label">Customized:</string>
+    <string name="customized_radius_label">Customized Radius:</string>
     <string name="add_remove_label">Add or remove states:</string>
     <string name="listener_label">Last selected state:</string>
     <string name="listener">{ index=%d, text=%s }</string>


### PR DESCRIPTION
Currently, it's default to 100 radius for the background. I've added customisable attribute where user can easily change the radius value.

Also, I've added a demo in sample app.

![photo_2022-06-17 12 06 45](https://user-images.githubusercontent.com/12107271/174277267-4af2d74d-3db8-4b07-940c-459cd37589eb.jpeg)
